### PR TITLE
Have a visualiser in these trying times

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -16,9 +16,11 @@
     	<!-- ProM packages. -->
     	<dependency org="prom" name="BasicUtils" rev="latest" changing="true" transitive="true" />
     	<dependency org="prom" name="Widgets" rev="latest" changing="true" transitive="true" />
-    	<dependency org="prom" name="InductiveVisualMiner" rev="latest" changing="true" transitive="true" />
     	<dependency org="prom" name="AcceptingPetriNet" rev="latest" changing="true" transitive="true" />
     	<dependency org="prom" name="LpSolve" rev="latest" changing="true" transitive="true" />
+    	<dependency org="prom" name="StochasticLabelledPetriNets" rev="latest" changing="true" transitive="true" />
+    	<dependency org="prom" name="DirectlyFollowsModelMiner" rev="latest" changing="true" transitive="true" />
+    	<dependency org="prom" name="XESLite" rev="latest" changing="true" transitive="true" />
     	<!-- Third party libraries. These may span multiple lines. -->
     	<!-- Please uncomment the second line in the resolve target in your build.xml file
     	     if you have any third party libraries. -->

--- a/src/org/processmining/longdistancedependencies/function/FunctionFactoryImpl.java
+++ b/src/org/processmining/longdistancedependencies/function/FunctionFactoryImpl.java
@@ -2,8 +2,7 @@ package org.processmining.longdistancedependencies.function;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import com.util.Arrays;
+import java.util.Arrays;
 
 public class FunctionFactoryImpl implements FunctionFactory {
 
@@ -120,14 +119,14 @@ public class FunctionFactoryImpl implements FunctionFactory {
 		if (power == 1) {
 			return variable(parameterIndex, name);
 		}
-		if (Arrays.contains(fixParameters, parameterIndex)) {
+		if (parameterIndex < fixParameters.length) {
 			return constant(1);
 		}
 		return new VariablePower(parameterIndex, name, power);
 	}
 
 	public Function variable(int parameterIndex, String name) {
-		if (Arrays.contains(fixParameters, parameterIndex)) {
+		if (parameterIndex < fixParameters.length) {
 			return constant(fixValue);
 		}
 		return new Variable(parameterIndex, name);

--- a/src/org/processmining/longdistancedependencies/function/FunctionFactoryNonReducing.java
+++ b/src/org/processmining/longdistancedependencies/function/FunctionFactoryNonReducing.java
@@ -1,7 +1,5 @@
 package org.processmining.longdistancedependencies.function;
 
-import com.util.Arrays;
-
 public class FunctionFactoryNonReducing implements FunctionFactory {
 
 	private final int[] fixParameters;
@@ -37,14 +35,14 @@ public class FunctionFactoryNonReducing implements FunctionFactory {
 	}
 
 	public Function variablePower(int parameterIndex, String name, int power) {
-		if (Arrays.contains(fixParameters, parameterIndex)) {
+		if (parameterIndex < fixParameters.length) {
 			return constant(1);
 		}
 		return new VariablePower(parameterIndex, name, power);
 	}
 
 	public Function variable(int parameterIndex, String name) {
-		if (Arrays.contains(fixParameters, parameterIndex)) {
+		if (parameterIndex < fixParameters.length) {
 			return constant(fixValue);
 		}
 		return new Variable(parameterIndex, name);

--- a/src/org/processmining/longdistancedependencies/plugins/FancyStochasticLabelledNetNetAdjustmentWeightsVisualisationPlugin.java
+++ b/src/org/processmining/longdistancedependencies/plugins/FancyStochasticLabelledNetNetAdjustmentWeightsVisualisationPlugin.java
@@ -1,0 +1,170 @@
+package org.processmining.longdistancedependencies.plugins;
+
+import java.text.DecimalFormat;
+
+import javax.swing.JComponent;
+
+import org.processmining.contexts.uitopia.annotations.UITopiaVariant;
+import org.processmining.contexts.uitopia.annotations.Visualizer;
+import org.processmining.framework.plugin.PluginContext;
+import org.processmining.framework.plugin.ProMCanceller;
+import org.processmining.framework.plugin.annotations.Plugin;
+import org.processmining.framework.plugin.annotations.PluginLevel;
+import org.processmining.framework.plugin.annotations.PluginVariant;
+import org.processmining.longdistancedependencies.StochasticLabelledPetriNetAdjustmentWeights;
+import org.processmining.plugins.InductiveMiner.plugins.dialogs.IMMiningDialog;
+import org.processmining.plugins.graphviz.dot.Dot;
+import org.processmining.plugins.graphviz.dot.DotNode;
+import org.processmining.plugins.graphviz.visualisation.DotPanel;
+
+public class FancyStochasticLabelledNetNetAdjustmentWeightsVisualisationPlugin
+		extends StochasticLabelledPetriNetAdjustmentWeightsVisualisationPlugin {
+
+	@Plugin(
+			name = "(Prettier) Stochastic labelled Petri net "
+					+ "(adjustment weights) visualisation",
+			returnLabels = {"Dot visualization" }, 
+			returnTypes = { JComponent.class }, 
+			parameterLabels = {
+					"stochastic labelled Petri net", 
+					"canceller" }, 
+			userAccessible = true, 
+			level = PluginLevel.Regular)
+	@Visualizer
+	@UITopiaVariant(
+			affiliation = "QUT",
+			author = "Adam Banham",
+			email = "adam_banham@hotmail.com")
+	@PluginVariant(
+			variantLabel = "(Prettier) Stochastic labelled Petri net visualisation",
+			requiredParameterLabels = { 0, 1 })
+	public JComponent visualise(
+			final PluginContext context,
+			StochasticLabelledPetriNetAdjustmentWeights net,
+			ProMCanceller canceller) {
+		DotPanel panel = visualise(net);
+		Dot dot = panel.getDot();
+		dot.setOption("bgcolor", "none");
+		return new DotPanel(dot);
+	}
+	
+	public static final String PlaceFill = "#f2f2f2";
+	public static final String StartingPlaceFill = "#80ff00";
+	public static final String EndingPlaceFill = "#FF3939";
+	public static final String TransitionFill = "#e9c6af";
+	public static final String TauFill = "#808080";
+	public static final String WeightFill = "#c0bbbb";
+	
+	public void decoratePlace(
+			StochasticLabelledPetriNetAdjustmentWeights net, 
+			int place, 
+			DotNode dotNode) {
+		dotNode.setOption("style", "filled");
+		if (net.isInInitialMarking(place) == 1) {
+			dotNode.setOption("fillcolor", StartingPlaceFill);
+		} else if (net.getOutputTransitions(place).length == 0) {
+			dotNode.setOption("fillcolor", EndingPlaceFill);
+		} else {
+			dotNode.setOption("fillcolor", PlaceFill);
+		}
+	}
+	
+	public String getTransitionLabel(
+			StochasticLabelledPetriNetAdjustmentWeights net,
+			int transition) {
+		String label = "";
+		if (net.isTransitionSilent(transition)) {
+			label = "&#120591;";
+		} else {
+			label = net.getTransitionLabel(transition);
+		}
+		return "<FONT>"
+			  +	label
+			  + "<FONT POINT-SIZE=\"10\">"
+			  + " ("
+			  + transition
+			  + ")"
+			  + "</FONT>"
+			  + "</FONT>";
+	}
+	
+	public void decorateTransition(StochasticLabelledPetriNetAdjustmentWeights net, int transition, DotNode dotNode) {
+		DecimalFormat f = new DecimalFormat("0.000");
+		f.setMaximumFractionDigits(3);
+		f.setMinimumFractionDigits(3);
+		
+		String transLabel = getTransitionLabel(net, transition);
+		if (net.isTransitionSilent(transition)) {
+			dotNode.setOption("fillcolor", TauFill);
+		} else {
+			dotNode.setOption("fillcolor", TransitionFill);
+		}
+
+		StringBuilder label = new StringBuilder();
+		label.append("<");
+		label.append("<TABLE"
+						+ " BORDER=\"0\" "
+						+ "><TR>"
+						+ "<TD><FONT POINT-SIZE=\"16\" >"
+						+ transLabel
+						+ "</FONT></TD>"
+						+ "</TR>"
+						+ "<TR>"
+						+ "<TD ALIGN=\"LEFT\">"
+						+ "<FONT ALIGN=\"LEFT\" POINT-SIZE=\"10\" >"
+						+ "<I>weight:</I>"
+						+ "</FONT>"
+						+ "</TD>"
+						+ "</TR>"
+						+ "<TR>"
+						+ "<TD BORDER=\"1\" BGCOLOR=\"#c0bbbb\" "
+						+ "STYLE=\"ROUNDED,DASHED\" "
+						+ "CELLPADDING=\"5\" "
+						+ ">"
+						+ f.format(net.getTransitionBaseWeight(transition))
+						+ "</TD>"
+						+ "</TR>"
+						+ ""
+		);
+		
+		StringBuilder paramLabel = new StringBuilder();
+		for (int transitionHistory = 0; transitionHistory < net.getNumberOfTransitions(); transitionHistory++) {
+			double adjustmentFactor = net.getTransitionAdjustmentWeight(transition, transitionHistory);
+			if (adjustmentFactor != 1.0) {
+				paramLabel.append( ""
+						+ "<TR>"
+						+ "<TD BORDER=\"1\" STYLE=\"rounded,dashed\" "
+						+ "BGCOLOR=\""
+						+ WeightFill
+						+ "\" CELLPADDING=\"5\" >"
+						+ "* "
+						+ f.format(adjustmentFactor)
+						+ " ^ "
+						+ "|"
+						+ getTransitionLabel(net, transitionHistory)
+						+ " |"
+						+ "</TD>"
+						+ "</TR>"
+				);
+			}
+		}
+		if (paramLabel.length() > 0) {
+			label.append( ""
+					+ "<TR>"
+					+ "<TD ALIGN=\"LEFT\">"
+					+ "<FONT ALIGN=\"LEFT\" POINT-SIZE=\"10\" >"
+					+ "<I>parameters:</I>"
+					+ "</FONT>"
+					+ "</TD>"
+					+ "</TR>"
+			);
+			label.append(paramLabel.toString());
+		}
+		label.append("</TABLE>");
+		label.append(">");
+
+		dotNode.setLabel(label.toString());
+		dotNode.setOption("style", "filled,rounded");
+	}
+	
+}

--- a/src/org/processmining/longdistancedependencies/solve/Solver.java
+++ b/src/org/processmining/longdistancedependencies/solve/Solver.java
@@ -23,6 +23,9 @@ public class Solver {
 	//other solvers:
 
 	//https://scipopt.org/index.php#license
+	
+	private static double LOWEST_PARAM_VAL = 0.001;
+	private static double HIGHEST_PARAM_VAL = Double.MAX_VALUE - 1.0;
 
 	/**
 	 * 
@@ -74,9 +77,23 @@ public class Solver {
 			public RealVector validate(RealVector params) {
 				//				System.out.println("validate " + params);
 				for (int i = 0; i < params.getDimension(); i++) {
-					if (params.getEntry(i) < 0) {
-						params.setEntry(i, 0);
-					} else if (fixedParametersb.get(i)) {
+					if (params.getEntry(i) < LOWEST_PARAM_VAL) {
+						params.setEntry(i, 
+								Double.min(
+									LOWEST_PARAM_VAL * 2, 
+									HIGHEST_PARAM_VAL
+								)
+						);
+					} else if (params.getEntry(i) > HIGHEST_PARAM_VAL) {
+						params.setEntry(i, 
+								Double.max(
+									LOWEST_PARAM_VAL,
+									HIGHEST_PARAM_VAL - 
+									((HIGHEST_PARAM_VAL - LOWEST_PARAM_VAL)/2.0)
+								)
+						);
+					}
+					else if (fixedParametersb.get(i)) {
 						params.setEntry(i, 1);
 					}
 				}


### PR DESCRIPTION
This PR was meant to focus on a visualiser that is somewhat close the themes in my thesis.  However, I ran into several issues when running the package locally. 

The first commit somewhat resolves the issues by updating the required packages in the ivy file. There was a utility `Arrays` imported from `com.util.Arrays` which I could not resolve, so I swapped the code for equivalent java 8 lines. It was used to determine if an index was in an array presumably so I just checked the length instead without the utility. However, the package still requires a local version of the current head of InductiveVisualMiner as a local project dependencies to compile without errors. It seems that the version pulled down by ivy does not match the current head, which is required for `IVMModel` constructor call with an `AcceptingPetriNet`.

The second commit is the visualiser plugin, which is a straightforward extension of the existing visualisers in the package already.
The visualiser uses a `DotPanel` and writes out parameters that are not equal to one, on transition instead of xlabels which make it a bit hard to follow at times. See an example of the visualiser below using the normative model for the road fines log:
![longdeps_demo](https://github.com/promworkbench/LongDistanceDependencies/assets/38652037/0fe545a8-69fd-489a-99bb-748ebd414993)

The third commit is an adjustment to the stochastic solver to prevent base weights from being optimized to zero, which is not against the connected paper, but is very weird. It still can be set to zero, but the handling of out of bounds parameters is controlled with an upper and lower bound instead. Unsure if that commit is needed or useful, but it was very weird to explain SLPN-SD when base weights are zero but has non-zero parameters.
